### PR TITLE
Fix cube coordinate offset when loading boards

### DIFF
--- a/Assets/Scripts/Managers/SaveLoadManager.cs
+++ b/Assets/Scripts/Managers/SaveLoadManager.cs
@@ -105,6 +105,9 @@ public class SaveLoadManager : MonoBehaviour
 
         Board board = new Board(new Vector2Int(data.Board.x_Height, data.Board.y_Width));
 
+        int qStart = -data.Board.x_Height / 2;
+        int rStart = -data.Board.y_Width / 2;
+
         for (int y = 0; y < data.Board.y_Width; y++)
         {
             for (int x = 0; x < data.Board.x_Height; x++)
@@ -115,7 +118,9 @@ public class SaveLoadManager : MonoBehaviour
                 GameObject holder = new GameObject($"Hex {x},{y}", typeof(Tile));
                 Tile tile = holder.GetComponent<Tile>();
                 tile.Data = tileType;
-                tile.SetPositionAndHeight(new Vector2Int(x, y), x, y, sTile.Height);
+                int q = qStart + x;
+                int r = rStart + y;
+                tile.SetPositionAndHeight(new Vector2Int(x, y), q, r, sTile.Height);
                 Vector3 tilePosition = mapContext.GetHexPositionFromCoordinate(new Vector2Int(x, y));
                 tilePosition.y += tile.Height / 2;
                 holder.transform.position = tilePosition;

--- a/Assets/Tests/BoardLookupPlayModeTests.cs
+++ b/Assets/Tests/BoardLookupPlayModeTests.cs
@@ -79,6 +79,25 @@ public class BoardLookupPlayModeTests
     }
 
     /// <summary>
+    /// Checks that cube coordinates begin at (-size/2,-size/2) so the board is
+    /// centred around the origin.  This mirrors how boards are generated in
+    /// RandomGeneration and other utilities.
+    /// </summary>
+    private void AssertCenteredCoords(Board board)
+    {
+        int qStart = -board._size_X / 2;
+        int rStart = -board._size_Y / 2;
+
+        Assert.AreEqual(qStart, board.get_Tile(0, 0).QAxis);
+        Assert.AreEqual(rStart, board.get_Tile(0, 0).RAxis);
+
+        Assert.AreEqual(qStart + board._size_X - 1,
+            board.get_Tile(board._size_X - 1, board._size_Y - 1).QAxis);
+        Assert.AreEqual(rStart + board._size_Y - 1,
+            board.get_Tile(board._size_X - 1, board._size_Y - 1).RAxis);
+    }
+
+    /// <summary>
     /// Verifies tiles can be found after randomly generating a board.
     /// </summary>
     [UnityTest]
@@ -127,6 +146,7 @@ public class BoardLookupPlayModeTests
 
         // Assert
         AssertBoardLookups(loaded);
+        AssertCenteredCoords(loaded);
 
         Object.Destroy(genGO);
         Object.Destroy(saveGO);


### PR DESCRIPTION
## Summary
- adjust cube coordinate calculation when loading boards from JSON so tiles align with generation behavior
- verify with a play mode test that loaded boards start their cube coordinates centered at (-size/2,-size/2)

## Testing
- `unity-editor -quit -batchmode -projectPath . -runTests -testPlatform playmode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb3020128832fb8b8fb9ff284ba41