### PR TITLE
Fix orientation when merging hex boards

### DIFF
--- a/Assets/Scripts/Map/MapMerge.cs
+++ b/Assets/Scripts/Map/MapMerge.cs
@@ -70,8 +70,7 @@ public class MapMerge : MonoBehaviour
 
     public static void MergeBoards(Map map, Board shipA, Board shipB, ShipSide sideToAttach)
     {
-        bool pointyTopped = !map.isFlatTopped;
-        var offsets = pointyTopped ? PointyOffsets : FlatOffsets;
+        var offsets = map.isFlatTopped ? FlatOffsets : PointyOffsets;
         Vector2Int dir = offsets[sideToAttach];
 
         int widthA = shipA._size_X;
@@ -108,6 +107,7 @@ public class MapMerge : MonoBehaviour
                     newTile.SetPosition(tilePos);
                     newTile.SetQUSPosition(cubeCoords.x, cubeCoords.y);
                     newTile.SetPawnPos();
+                    newTile.SetupHexRenderer(map.innerSize, map.outerSize, map.isFlatTopped);
 
                     map.PlayArea.set_Tile(mx, my, newTile);
                     newTile.transform.position = map.GetHexPositionFromCoordinate(tilePos);
@@ -132,6 +132,7 @@ public class MapMerge : MonoBehaviour
                     newTile.SetPosition(tilePos);
                     newTile.SetQUSPosition(cubeCoords.x, cubeCoords.y);
                     newTile.SetPawnPos();
+                    newTile.SetupHexRenderer(map.innerSize, map.outerSize, map.isFlatTopped);
 
                     map.PlayArea.set_Tile(mx, my, newTile);
                     newTile.transform.position = map.GetHexPositionFromCoordinate(tilePos);

--- a/Assets/Tests/BoardLookupPlayModeTests.cs
+++ b/Assets/Tests/BoardLookupPlayModeTests.cs
@@ -160,6 +160,36 @@ public class BoardLookupPlayModeTests
     }
 
     /// <summary>
+    /// Merging should initialise each tile's renderer using the map's
+    /// orientation so that meshes face the correct direction.
+    /// </summary>
+    [UnityTest]
+    public IEnumerator MergeBoards_RespectsMapOrientation([Values(true, false)] bool flat)
+    {
+        // Arrange
+        EnsureCamera();
+        var map = CreateBasicMap(new Vector2Int(2, 2));
+        map.isFlatTopped = flat;
+        var genGO = new GameObject("Gen");
+        var gen = genGO.AddComponent<RandomGeneration>();
+        Board a = gen.Generate(map);
+        Board b = gen.Generate(map);
+
+        // Act
+        MapMerge.MergeBoards(map, a, b, ShipSide.Bow);
+        yield return null;
+
+        // Assert - every tile should adopt the map's orientation
+        foreach (var tile in map.PlayArea.GetAllTiles())
+        {
+            Assert.AreEqual(flat, tile.Hex.isFlatTopped);
+        }
+
+        Object.Destroy(genGO);
+        Object.Destroy(map.gameObject);
+    }
+
+    /// <summary>
     /// Rotates an existing board and confirms that rotated tiles maintain
     /// valid cube coordinate lookups.
     /// </summary>


### PR DESCRIPTION
## Summary
- use map orientation to select offset dictionary
- initialise newly merged tiles with correct orientation
- add tests covering merged board orientation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684fb336ac40832fa912c314b182b0cd