### PR TITLE
⚡ Avoid implicit material cloning in HexRenderer.currentMat

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - [O(N) Graph Initialization in Pathfinding]
 **Learning:** The pathfinding system was re-initializing the entire grid graph (creating `PathNode` objects and calculating heuristics for ALL tiles) for *every* path request. This is O(N) where N is map size, which is extremely wasteful for short paths or frequent queries (like mouse movement highlighting).
 **Action:** Implemented lazy node initialization and a Binary Heap (MinHeap) for the open list. Always check if a system processes the entire dataset when it only needs a subset.
+
+## 2024-10-27 - [Material Instantiation Overhead]
+**Learning:** Accessing the `.material` property of a Unity `MeshRenderer` automatically creates a unique instance (clone) of the material if one doesn't exist, which can lead to significant memory and CPU overhead if done frequently (e.g., on every tile of a large hex map).
+**Action:** Replaced `.material` with `.sharedMaterial` for read-only access in `HexRenderer.currentMat()`. Always use `.sharedMaterial` when you do not intend to modify the material properties for that specific instance.

--- a/Assets/Scripts/Map/Tiles/HexRenderer.cs
+++ b/Assets/Scripts/Map/Tiles/HexRenderer.cs
@@ -140,7 +140,7 @@ public class HexRenderer : MonoBehaviour
 
     public Material currentMat()
     {
-        return H_Meshrenderer.material;
+        return H_Meshrenderer.sharedMaterial;
     }
 
     //Creates a mesh to be used as the colider mesh, which is the same as the drawn mesh but with a flat hex on top.

--- a/Assets/Tests/EditMode/HexRendererMaterialTests.cs
+++ b/Assets/Tests/EditMode/HexRendererMaterialTests.cs
@@ -1,0 +1,60 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests.EditMode
+{
+    public class HexRendererMaterialTests
+    {
+        private class TestHexRenderer : HexRenderer
+        {
+            // Expose internals if needed, but currentMat is public
+        }
+
+        [Test]
+        public void CurrentMat_ReturnsCorrectMaterial()
+        {
+            var go = new GameObject("HexRendererTest");
+            var renderer = go.AddComponent<TestHexRenderer>();
+            var meshRenderer = go.GetComponent<MeshRenderer>();
+
+            // Attempt to find a basic shader
+            var shader = Shader.Find("Standard");
+            if (shader == null)
+            {
+                // Fallback for some test environments
+                shader = Shader.Find("Hidden/InternalErrorShader");
+            }
+
+            // If we still can't find a shader, we might be in a very limited env,
+            // but we'll try to proceed.
+            // Note: In some headless Unity envs, Shader.Find might return null for everything.
+            // If so, we can't easily test Material creation.
+            // But let's assume we can.
+
+            if (shader != null)
+            {
+                var mat = new Material(shader);
+                mat.name = "TestMaterial";
+
+                // Update the mesh renderer with this material
+                // We use meshupdate which sets .material = Mat
+                renderer.meshupdate(mat);
+
+                // Verify currentMat returns a material
+                var result = renderer.currentMat();
+                Assert.IsNotNull(result);
+                // We don't check for "(Instance)" suffix strictly because environment behavior might vary,
+                // but we ensure it matches the renderer's active material.
+
+                // Ensure it matches what's on the renderer
+                Assert.AreEqual(meshRenderer.sharedMaterial, result);
+            }
+            else
+            {
+                Assert.Ignore("Could not find a valid shader to create a material for testing.");
+            }
+
+            Object.DestroyImmediate(go);
+        }
+    }
+}


### PR DESCRIPTION
💡 **What:** Replaced access to `.material` with `.sharedMaterial` in `HexRenderer.currentMat()`.
🎯 **Why:** Accessing the `.material` property on a `MeshRenderer` automatically creates a unique clone of the material if one doesn't exist. For read-only access (like checking the current material), this is unnecessary overhead that can lead to excessive memory usage and CPU time, especially on a hex grid with many tiles.
📊 **Measured Improvement:**
*   **Baseline:** `currentMat()` access would trigger material instantiation (cloning) if not already instantiated.
*   **Improvement:** `currentMat()` now returns the shared material reference without triggering instantiation.
*   **Note:** Performance impact could not be measured directly due to the lack of a local Unity runtime, but this is a standard Unity optimization pattern. A verification test `Assets/Tests/EditMode/HexRendererMaterialTests.cs` was added to ensure the method still correctly returns the active material.

---
*PR created automatically by Jules for task [4758910081203090147](https://jules.google.com/task/4758910081203090147) started by @arran4*