### PR TITLE
Implement game restart and hand redeal logic

### DIFF
--- a/Assets/Scripts/CardGame/CardBoard.cs
+++ b/Assets/Scripts/CardGame/CardBoard.cs
@@ -466,7 +466,11 @@ public class CardBoard : MonoBehaviour
             for (int y = 0; y < GRID_SIZE; y++)
             {
                 board[x, y] = null;
-                visuals[x, y] = null;
+                if (visuals[x, y] != null)
+                {
+                    Destroy(visuals[x, y].gameObject);
+                    visuals[x, y] = null;
+                }
             }
     }
 

--- a/Assets/Scripts/CardGame/CardGameStateMachine.cs
+++ b/Assets/Scripts/CardGame/CardGameStateMachine.cs
@@ -27,6 +27,7 @@ public class GameStateMachine : MonoBehaviour
     [SerializeField] private CardBoard cardBoard;
     [SerializeField] private Hand playerHand;
     [SerializeField] private Hand opponentHand;
+    [SerializeField] private GameLayout gameLayout;
 
     [Header("State")]
     [SerializeField] private GameState currentState;
@@ -264,9 +265,19 @@ public class GameStateMachine : MonoBehaviour
 
     public void RestartGame()
     {
-        cardBoard.ResetBoard();
-        // TODO: Reset hands and redeal cards
+        if (gameLayout == null)
+            gameLayout = FindObjectOfType<GameLayout>();
 
+        gameLayout.ClearLayout();
+        cardBoard.ResetBoard();
+        gameLayout.SpawnSlateVisual();
+
+        playerHand.ResetHand();
+        opponentHand.ResetHand();
+
+        hasStarted = false;
+        hasSwapped = false;
+        ChangeState(GameState.GameStart);
     }
     private void FinalizeTurn()
     {

--- a/Assets/Scripts/CardGame/GameLayout.cs
+++ b/Assets/Scripts/CardGame/GameLayout.cs
@@ -37,6 +37,8 @@ public class GameLayout : MonoBehaviour
     private readonly Dictionary<Slate, Visualiser> cardVisuals
     = new Dictionary<Slate, Visualiser>();
 
+    private Visualiser currentSlateVisual;
+
 
     public void Start()
     {
@@ -190,7 +192,7 @@ public class GameLayout : MonoBehaviour
         }
     }
 
-    private void SpawnSlateVisual()
+    public void SpawnSlateVisual()
     {
         Vector2Int slatePos = cardBoard.FindSlate();
         Slate slate = cardBoard.GetCard(slatePos);
@@ -202,6 +204,7 @@ public class GameLayout : MonoBehaviour
         }
 
         Visualiser visual = Instantiate(slateVisualPrefab);
+        currentSlateVisual = visual;
         visual.Setup(slate);
         visual.GetComponent<CardSelect>().enabled = false;
 
@@ -209,6 +212,16 @@ public class GameLayout : MonoBehaviour
 
         RegisterVisual(slate, visual);
         UpdateGridVisuals();
+    }
+
+    public void ClearLayout()
+    {
+        if (currentSlateVisual != null)
+        {
+            Destroy(currentSlateVisual.gameObject);
+            currentSlateVisual = null;
+        }
+        cardVisuals.Clear();
     }
 
     public Visualiser GetVisualForCard(Slate card)

--- a/Assets/Scripts/CardGame/Hand.cs
+++ b/Assets/Scripts/CardGame/Hand.cs
@@ -36,15 +36,37 @@ public class Hand : MonoBehaviour
             gameLayout = FindObjectOfType<GameLayout>();
         }
 
+        InitializeHand();
+    }
+
+    public void InitializeHand()
+    {
         foreach (SOCard a in SOPlayerHand)
         {
             Card card = new Card(a, Player);
             Visualiser view = Instantiate(cardView);
             view.Setup(card);
-            gameLayout.RegisterVisual(card, view);
+            if (gameLayout != null)
+            {
+                gameLayout.RegisterVisual(card, view);
+            }
             PlayerHand.Add(card);
             handVisualisers.Add(view);
         }
+    }
+
+    public void ResetHand()
+    {
+        foreach (var visualiser in handVisualisers)
+        {
+            if (visualiser != null)
+            {
+                Destroy(visualiser.gameObject);
+            }
+        }
+        handVisualisers.Clear();
+        PlayerHand.Clear();
+        InitializeHand();
     }
 
 


### PR DESCRIPTION
Implemented `RestartGame` in `CardGameStateMachine` to properly reset hands, board, and layout visuals. Added `ResetHand` to `Hand.cs`, `ResetBoard` visual cleanup to `CardBoard.cs`, and `ClearLayout` to `GameLayout.cs` to ensure clean state and avoid memory leaks.

---
*PR created automatically by Jules for task [14624232206543218177](https://jules.google.com/task/14624232206543218177) started by @arran4*