### PR TITLE
Card Game Win/Loss UI and Rematch Logic

### DIFF
--- a/Assets/Scripts/CardGame/CardGameStateMachine.cs
+++ b/Assets/Scripts/CardGame/CardGameStateMachine.cs
@@ -223,9 +223,6 @@ public class GameStateMachine : MonoBehaviour
 
         OnGameEnd?.Invoke(playerWon);
         ChangeState(GameState.GameOver);
-
-        // TODO: Show win/loss UI
-        // TODO: Offer rematch option
     }
 
     // ========================================================================
@@ -264,9 +261,14 @@ public class GameStateMachine : MonoBehaviour
 
     public void RestartGame()
     {
-        cardBoard.ResetBoard();
-        // TODO: Reset hands and redeal cards
+        Debug.Log("Restarting game...");
 
+        cardBoard.RedistributeCards(playerHand, opponentHand);
+        cardBoard.ResetBoard();
+
+        hasStarted = false;
+        hasSwapped = false;
+        ChangeState(GameState.GameStart);
     }
     private void FinalizeTurn()
     {

--- a/Assets/Scripts/CardGame/GameEndUI.cs
+++ b/Assets/Scripts/CardGame/GameEndUI.cs
@@ -1,19 +1,33 @@
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using System.Collections;
 
 public class GameEndUI : MonoBehaviour
 {
     [Header("UI References")]
     [SerializeField] private GameObject panel;
+    [SerializeField] private CanvasGroup panelCanvasGroup;
     [SerializeField] private TextMeshProUGUI resultText;
     [SerializeField] private Button rematchButton;
+
+    [Header("Animation Settings")]
+    [SerializeField] private float fadeDuration = 0.5f;
+    [SerializeField] private float textScaleDuration = 0.5f;
+    [SerializeField] private Vector3 textFinalScale = Vector3.one;
+    [SerializeField] private Vector3 textInitialScale = Vector3.zero;
 
     private void Start()
     {
         // Ensure panel is hidden at start
         if (panel != null)
+        {
             panel.SetActive(false);
+            if (panelCanvasGroup != null)
+            {
+                panelCanvasGroup.alpha = 0f;
+            }
+        }
 
         // Subscribe to GameStateMachine events
         if (GameStateMachine.Instance != null)
@@ -45,14 +59,50 @@ public class GameEndUI : MonoBehaviour
         if (panel != null)
         {
             panel.SetActive(true);
+
+            // Set Text
+            if (resultText != null)
+            {
+                resultText.text = playerWon ? "VICTORY!" : "DEFEAT";
+                resultText.color = playerWon ? new Color(0.2f, 0.8f, 0.2f) : new Color(0.8f, 0.2f, 0.2f); // Vibrant Green / Red
+                resultText.transform.localScale = textInitialScale;
+            }
+
+            // Start Animations
+            StartCoroutine(AnimateUI());
+        }
+    }
+
+    private IEnumerator AnimateUI()
+    {
+        float elapsed = 0f;
+
+        while (elapsed < fadeDuration)
+        {
+            elapsed += Time.deltaTime;
+            float t = Mathf.Clamp01(elapsed / fadeDuration);
+
+            // Fade in panel
+            if (panelCanvasGroup != null)
+            {
+                panelCanvasGroup.alpha = t;
+            }
+
+            // Pop text
+            if (resultText != null && elapsed < textScaleDuration)
+            {
+                float scaleT = Mathf.Clamp01(elapsed / textScaleDuration);
+                // Simple elastic-like overshoot could be added here, but SmoothStep is fine for now
+                float smoothScale = Mathf.SmoothStep(0f, 1f, scaleT);
+                resultText.transform.localScale = Vector3.Lerp(textInitialScale, textFinalScale, smoothScale);
+            }
+
+            yield return null;
         }
 
-        if (resultText != null)
-        {
-            resultText.text = playerWon ? "YOU WIN!" : "YOU LOSE!";
-            // Optional: Change color based on win/loss
-            resultText.color = playerWon ? Color.green : Color.red;
-        }
+        // Ensure final values
+        if (panelCanvasGroup != null) panelCanvasGroup.alpha = 1f;
+        if (resultText != null) resultText.transform.localScale = textFinalScale;
     }
 
     private void OnRematchClicked()
@@ -60,9 +110,15 @@ public class GameEndUI : MonoBehaviour
         if (GameStateMachine.Instance != null)
         {
             GameStateMachine.Instance.RestartGame();
+
+            // Hide UI immediately
             if (panel != null)
             {
                 panel.SetActive(false);
+                if (panelCanvasGroup != null)
+                {
+                    panelCanvasGroup.alpha = 0f;
+                }
             }
         }
     }

--- a/Assets/Scripts/CardGame/GameEndUI.cs
+++ b/Assets/Scripts/CardGame/GameEndUI.cs
@@ -1,0 +1,69 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class GameEndUI : MonoBehaviour
+{
+    [Header("UI References")]
+    [SerializeField] private GameObject panel;
+    [SerializeField] private TextMeshProUGUI resultText;
+    [SerializeField] private Button rematchButton;
+
+    private void Start()
+    {
+        // Ensure panel is hidden at start
+        if (panel != null)
+            panel.SetActive(false);
+
+        // Subscribe to GameStateMachine events
+        if (GameStateMachine.Instance != null)
+        {
+            GameStateMachine.Instance.OnGameEnd += HandleGameEnd;
+        }
+        else
+        {
+            Debug.LogWarning("GameStateMachine Instance not found!");
+        }
+
+        // Setup button listener
+        if (rematchButton != null)
+        {
+            rematchButton.onClick.AddListener(OnRematchClicked);
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (GameStateMachine.Instance != null)
+        {
+            GameStateMachine.Instance.OnGameEnd -= HandleGameEnd;
+        }
+    }
+
+    private void HandleGameEnd(bool playerWon)
+    {
+        if (panel != null)
+        {
+            panel.SetActive(true);
+        }
+
+        if (resultText != null)
+        {
+            resultText.text = playerWon ? "YOU WIN!" : "YOU LOSE!";
+            // Optional: Change color based on win/loss
+            resultText.color = playerWon ? Color.green : Color.red;
+        }
+    }
+
+    private void OnRematchClicked()
+    {
+        if (GameStateMachine.Instance != null)
+        {
+            GameStateMachine.Instance.RestartGame();
+            if (panel != null)
+            {
+                panel.SetActive(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented the Win/Loss UI for the Card Game as requested. 
Created `GameEndUI.cs` which subscribes to `GameStateMachine.OnGameEnd` to show the result.
Implemented the `RestartGame` logic in `CardGameStateMachine.cs` to support the "Rematch" button, ensuring cards are redistributed and the board is reset correctly.

---
*PR created automatically by Jules for task [17622353693824627286](https://jules.google.com/task/17622353693824627286) started by @arran4*